### PR TITLE
Add Firebase login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,22 @@ Join our community of developers creating universal apps.
 
 - [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
 - [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions.
+
+## Authentication
+
+This project uses [Firebase Authentication](https://firebase.google.com/docs/auth) for login. Update `firebaseConfig.ts` with your Firebase project credentials. The app starts by checking the current authentication state and redirects to the login screen if the user is not signed in.
+
+Credentials are read from `firebaseConfig.ts`:
+
+```ts
+const firebaseConfig = {
+  apiKey: 'YOUR_API_KEY',
+  authDomain: 'YOUR_AUTH_DOMAIN',
+  projectId: 'YOUR_PROJECT_ID',
+  storageBucket: 'YOUR_STORAGE_BUCKET',
+  messagingSenderId: 'YOUR_MESSAGING_SENDER_ID',
+  appId: 'YOUR_APP_ID',
+};
+```
+
+Replace these placeholders with your project's values before running the app.

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function RootLayout() {
+  return <Stack />;
+}

--- a/app/home.tsx
+++ b/app/home.tsx
@@ -1,0 +1,33 @@
+import { View, Text, Button, StyleSheet } from 'react-native';
+import { signOut } from 'firebase/auth';
+import { auth } from '../firebaseConfig';
+import { Stack, useRouter } from 'expo-router';
+
+export default function HomeScreen() {
+  const router = useRouter();
+
+  const onLogout = async () => {
+    await signOut(auth);
+    router.replace('/login');
+  };
+
+  return (
+    <View style={styles.container}>
+      <Stack.Screen options={{ title: 'Home' }} />
+      <Text style={styles.text}>Welcome!</Text>
+      <Button title="Logout" onPress={onLogout} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  text: {
+    fontSize: 20,
+    marginBottom: 20,
+  },
+});

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import { onAuthStateChanged, User } from 'firebase/auth';
+import { auth } from '../firebaseConfig';
+import { Redirect } from 'expo-router';
+
+export default function Index() {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (u) => {
+      setUser(u);
+      setLoading(false);
+    });
+    return unsubscribe;
+  }, []);
+
+  if (loading) return null;
+
+  return <Redirect href={user ? '/home' : '/login'} />;
+}

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { View, TextInput, Button, StyleSheet, Alert } from 'react-native';
+import { Stack, useRouter } from 'expo-router';
+import { signInWithEmailAndPassword } from 'firebase/auth';
+import { auth } from '../firebaseConfig';
+
+export default function LoginScreen() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const router = useRouter();
+
+  const onLogin = async () => {
+    try {
+      await signInWithEmailAndPassword(auth, email, password);
+      router.replace('/home');
+    } catch (e: any) {
+      Alert.alert('Login Failed', e.message);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Stack.Screen options={{ title: 'Login' }} />
+      <TextInput
+        style={styles.input}
+        placeholder="Email"
+        autoCapitalize="none"
+        keyboardType="email-address"
+        value={email}
+        onChangeText={setEmail}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Password"
+        secureTextEntry
+        value={password}
+        onChangeText={setPassword}
+      />
+      <Button title="Login" onPress={onLogin} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 16,
+  },
+  input: {
+    height: 40,
+    borderColor: '#ccc',
+    borderWidth: 1,
+    paddingHorizontal: 8,
+    marginBottom: 12,
+  },
+});

--- a/firebaseConfig.ts
+++ b/firebaseConfig.ts
@@ -1,0 +1,15 @@
+import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+
+const firebaseConfig = {
+  apiKey: 'YOUR_API_KEY',
+  authDomain: 'YOUR_AUTH_DOMAIN',
+  projectId: 'YOUR_PROJECT_ID',
+  storageBucket: 'YOUR_STORAGE_BUCKET',
+  messagingSenderId: 'YOUR_MESSAGING_SENDER_ID',
+  appId: 'YOUR_APP_ID',
+};
+
+const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export default app;


### PR DESCRIPTION
## Summary
- add Firebase config
- implement login and home screens
- redirect based on auth status
- document authentication setup

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847047aac108323b03600b657c45300